### PR TITLE
Allow for custom resolvers for any property

### DIFF
--- a/lib/generators/type.js
+++ b/lib/generators/type.js
@@ -277,9 +277,7 @@ function Generate (document, implementations) {
             type: getOutputType(field.type),
             description: getDescription(),
             args: args,
-            resolve: !isInterface && field.arguments
-              ? implementations[typeName][field.name.value]
-              : undefined
+            resolve: !isInterface && implementations[typeName] ? implementations[typeName][field.name.value] : undefined
             // TODO: deprecationReason: string
           };
           break;

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,6 @@ var parse = require('./parse')
 /**
  * Generators
  */
-
-var Schema = require('./generators/schema')
 var Type = require('./generators/type')
 
 /**


### PR DESCRIPTION
Removes the `field.arguments` check, allowing a custom resolver to be specified for any field.
