### PR TITLE
Expose schema

### DIFF
--- a/lib/generators/type.js
+++ b/lib/generators/type.js
@@ -277,9 +277,7 @@ function Generate (document, implementations) {
             type: getOutputType(field.type),
             description: getDescription(),
             args: args,
-            resolve: !isInterface && field.arguments
-              ? implementations[typeName][field.name.value]
-              : undefined
+            resolve: !isInterface && implementations[typeName] ? implementations[typeName][field.name.value] : undefined
             // TODO: deprecationReason: string
           };
           break;

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,6 @@ var parse = require('./parse')
 /**
  * Generators
  */
-
-var Schema = require('./generators/schema')
 var Type = require('./generators/type')
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,20 @@ function Create (schema, implementation) {
     subscription: object_types['Subscription']
   });
 
-  return function query (query, params, root_value, operation) {
+  var logged;
+
+  function query(query, params, root_value, operation) {
+    if (!logged) {
+      console.log('graph.ql - deprecated: schema(...), use schema.query(...) instead.')
+      logged = true
+    }
+    return query.query(query, params, root_value, operation)
+  }
+
+  query.query = function(query, params, root_value, operation) {
     return graphql.graphql(schema, query, root_value, params || {}, operation)
   }
+  query.schema = schema
+
+  return query
 }


### PR DESCRIPTION
Exposes `.query` and `.schema`, so the schema can be read by tools like graphiql. Added as static props on the returned function and a deprecation warning so it doesn't break for people depending on it for now. Forked from code from PR #9
