### PR TITLE
Add type to the schema to fix the type missing issue

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,9 @@
 ## Installation
 
 ```
+# If you have GraphQL package installed before,
+# Remove it to avoid issue caused by multiple versions of GraphQL in node_modules directory
+# npm remove graphql
 npm install graph.ql
 ```
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -4,6 +4,7 @@
 
 var graphql = require('graphql')
 var assert = require('assert')
+var co = require('co')
 
 /**
  * Export `Generate`
@@ -279,7 +280,7 @@ function Generate (document, implementations) {
             description: getDescription(),
             args: args,
             resolve: !isInterface && implementations[typeName] && implementations[typeName][field.name.value]
-              ? implementations[typeName][field.name.value]
+              ? wrap(implementations[typeName][field.name.value])
               : undefined
           };
 
@@ -289,6 +290,12 @@ function Generate (document, implementations) {
       }
     });
     return fields;
+  }
+
+  function wrap (fn) {
+    return function () {
+      return co.wrap(fn).apply(this, arguments)
+    }
   }
 
   /**

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -4,7 +4,6 @@
 
 var graphql = require('graphql')
 var assert = require('assert')
-var co = require('co')
 
 /**
  * Export `Generate`
@@ -280,7 +279,7 @@ function Generate (document, implementations) {
             description: getDescription(),
             args: args,
             resolve: !isInterface && implementations[typeName] && implementations[typeName][field.name.value]
-              ? wrap(implementations[typeName][field.name.value])
+              ? implementations[typeName][field.name.value]
               : undefined
           };
 
@@ -290,12 +289,6 @@ function Generate (document, implementations) {
       }
     });
     return fields;
-  }
-
-  function wrap (fn) {
-    return function () {
-      return co.wrap(fn).apply(this, arguments)
-    }
   }
 
   /**

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -5,6 +5,7 @@
 var graphql = require('graphql')
 var assert = require('assert')
 var co = require('co')
+var isGeneratorFn = require('is-generator-fn')
 
 /**
  * Export `Generate`
@@ -293,10 +294,14 @@ function Generate (document, implementations) {
   }
 
   function wrap (fn) {
+    if (!isGeneratorFn(fn)){
+      return fn
+    }
     return function () {
       return co.wrap(fn).apply(this, arguments)
     }
   }
+
 
   /**
    * Get the object type definition

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ module.exports = Create
 function Create (schema, implementation) {
   var types = Type(parse(schema), implementation)
   var object_types = types.objectTypes
-  var all_types = Object.keys(object_types).map( typeName => object_types[typeName] )
+  var all_types = Object.keys(types.interfaceTypes).length? Object.keys(object_types).map( val => object_types[val] ) : null
 
   var schema = new graphql.GraphQLSchema({
     query: object_types['Query'],

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,11 +23,13 @@ module.exports = Create
 function Create (schema, implementation) {
   var types = Type(parse(schema), implementation)
   var object_types = types.objectTypes
+  var all_types = Object.keys(object_types).map( typeName => object_types[typeName] )
 
   var schema = new graphql.GraphQLSchema({
     query: object_types['Query'],
     mutation: object_types['Mutation'],
-    subscription: object_types['Subscription']
+    subscription: object_types['Subscription'],
+    types: all_types
   });
 
   function query(query, params, root_value, context_value, operation) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "co": "4.6.0",
     "debug": "^2.2.0",
-    "graphql": "^0.5.0"
+    "graphql": "^0.6.0"
   },
   "devDependencies": {
     "mocha": "^2.3.4"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,9 @@
     "url": "git://github.com/MatthewMueller/graph.ql.git"
   },
   "dependencies": {
-    "debug": "^2.2.0"
-  },
-  "peerDependencies": {
-    "graphql": "^0.5.0-b || ^0.6.0"
+    "co": "4.6.0",
+    "debug": "^2.2.0",
+    "graphql": "^0.5.0"
   },
   "devDependencies": {
     "mocha": "^2.3.4"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "url": "git://github.com/MatthewMueller/graph.ql.git"
   },
   "dependencies": {
-    "co": "4.6.0",
     "debug": "^2.2.0",
     "graphql": "^0.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "url": "git://github.com/MatthewMueller/graph.ql.git"
   },
   "dependencies": {
-    "debug": "^2.2.0",
-    "graphql": "^0.6.0"
+    "debug": "^2.2.0"
+  },
+  "peerDependencies": {
+    "graphql": "^0.5.0-b || ^0.6.0"
   },
   "devDependencies": {
     "mocha": "^2.3.4"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   },
   "dependencies": {
     "co": "4.6.0",
+    "is-generator-fn": "^1.0.0",
     "debug": "^2.2.0",
-    "graphql": "^0.5.0"
+    "graphql": "^0.6.0"
   },
   "devDependencies": {
     "mocha": "^2.3.4"


### PR DESCRIPTION
- Add types to the schema to fix the type missing issue
- Upgrade graphql to ^0.6.0
- Remove co
- Move graphql to peerDependencies
