### PR TITLE
Change graphql into a peer dependency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@
 ## Installation
 
 ```
-npm install graph.ql
+npm install graphql graph.ql
 ```
 
 ## Example

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
   },
   "dependencies": {
     "co": "4.6.0",
-    "debug": "^2.2.0",
-    "graphql": "0.7.1"
+    "debug": "^2.2.0"
+  },
+  "peerDependencies": {
+    "graphql": "^0.7.1"
   },
   "devDependencies": {
     "mocha": "^2.3.4"


### PR DESCRIPTION
Hi,

Great project; I find writing graphql with this is great. However, I have ran into issues where the internal graphql version used by this package is hard coded at 0.7.1 while the latest is 0.8.2. `graphql.GraphQLSchema` must come from the same version as internally there are numerous instanceof checks on the objects. 

This pull request changes graphql into a peer dependecy so any version can be used and the package will still work. So far it seems okay on my system. There are no huge changes in v0.7.1 to v0.8.2  from looking at their change long. Couple of spec changes that don't seem to have any impact so far from my testing.

This will change the install procedure from `npm install graph.ql` into `npm install graphql graph.ql` which is a bit confusing however, will reduce the burden on this package from keeping up with their version changes.

Hope that is clear, as I am typing this out a bit in a hurry. 

Thanks,

Amandeep