### PR TITLE
bump graphql version to 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "co": "4.6.0",
     "debug": "^2.2.0",
-    "graphql": "0.7.1"
+    "graphql": "0.9.1"
   },
   "devDependencies": {
     "mocha": "^2.3.4"


### PR DESCRIPTION
hey there. thanks for the project, it helps a lot. however, upstream graphql has gained two minor versions, so, how about bumping it up?